### PR TITLE
Hue Python 3 MySQL Support

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -22670,3 +22670,32 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
+---
+
+MIT License
+(PyMySQL)
+
+MIT License
+=======================
+
+Copyright (c) 2010, 2013 PyMySQL contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -59,6 +59,7 @@ python-pam==2.0.2
 pytidylib==0.3.2
 pytz==2021.3
 PyJWT==2.4.0
+PyMySQL==1.1.0
 PyYAML==6.0.1
 requests-kerberos==0.12.0
 rsa==4.7.2

--- a/desktop/core/ext-py3/eventlet-0.30.2/eventlet/green/MySQLdb.py
+++ b/desktop/core/ext-py3/eventlet-0.30.2/eventlet/green/MySQLdb.py
@@ -1,3 +1,6 @@
+import pymysql
+pymysql.install_as_MySQLdb()
+
 __MySQLdb = __import__('MySQLdb')
 
 __all__ = __MySQLdb.__all__

--- a/desktop/core/ext-py3/eventlet-0.30.2/tests/db_pool_test.py
+++ b/desktop/core/ext-py3/eventlet-0.30.2/tests/db_pool_test.py
@@ -19,6 +19,8 @@ except ImportError:
 
 MySQLdb = None
 try:
+    import pymysql
+    pymysql.install_as_MySQLdb()
     import MySQLdb
 except ImportError:
     pass

--- a/desktop/core/ext-py3/eventlet-0.30.2/tests/isolated/mysqldb_monkey_patch.py
+++ b/desktop/core/ext-py3/eventlet-0.30.2/tests/isolated/mysqldb_monkey_patch.py
@@ -1,6 +1,8 @@
 __test__ = False
 
 if __name__ == '__main__':
+    import pymysql
+    pymysql.install_as_MySQLdb()
     import MySQLdb as m
     from eventlet import patcher
     from eventlet.green import MySQLdb as gm

--- a/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
+++ b/desktop/libs/librdbms/src/librdbms/server/mysql_lib.py
@@ -19,6 +19,8 @@ import logging
 import sys
 
 try:
+  import pymysql
+  pymysql.install_as_MySQLdb()
   import MySQLdb as Database
 except ImportError as e:
   from django.core.exceptions import ImproperlyConfigured

--- a/tools/cloudera/build_hue_common.sh
+++ b/tools/cloudera/build_hue_common.sh
@@ -103,8 +103,6 @@ function redhat8_ppc_install() {
       xmlsec1-openssl \
       libss \
       ncurses-devel'
-    # MySQLdb install
-    sudo -- sh -c 'yum install -y python3-mysqlclient'
     # NODEJS 14 install
     sudo -- sh -c 'yum install -y nodejs npm'
     # Pip modules install
@@ -133,8 +131,6 @@ function redhat9_ppc_install() {
       xmlsec1-openssl \
       libss \
       ncurses-devel'
-    # MySQLdb install
-    sudo -- sh -c 'yum install -y python3-mysqlclient'
     # NODEJS 14 install
     sudo -- sh -c 'yum install -y nodejs npm'
     # Pip modules install
@@ -164,8 +160,8 @@ function sles12_install() {
       ncurses-devel \
       nmap \
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
-    # MySQLdb install
-    sudo -- sh -c 'zypper install -y libmysqlclient-devel libmysqlclient18 libmysqld18 libmysqld-devel'
+    # MySQLdb install -- Removed MySQLdb
+    sudo -- sh -c 'zypper install -y libmysqld18 libmysqld-devel'
     # NODEJS 14 install
     sudo -- sh -c 'zypper install -y npm14 nodejs14'
     # Pip modules install
@@ -194,7 +190,7 @@ function sles15_install() {
       nmap \
       xmlsec1 xmlsec1-devel  xmlsec1-openssl-devel'
     # MySQLdb install
-    sudo -- sh -c 'zypper install -y libmariadb-devel mariadb-client python3-mysqlclient'
+    sudo -- sh -c 'zypper install -y libmariadb-devel mariadb-client 
     # NODEJS 14 install
     sudo -- sh -c 'zypper install -y nodejs18 npm16'
     # Pip modules install
@@ -263,8 +259,6 @@ function redhat8_install() {
       xmlsec1-openssl \
       libss \
       ncurses-c++-libs'
-    # MySQLdb install
-    sudo -- sh -c 'yum install -y python3-mysqlclient'
     # NODEJS 14 install
     sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
     # Pip modules install
@@ -384,8 +378,6 @@ function redhat9_install() {
       xmlsec1-openssl \
       libss \
       ncurses-c++-libs'
-    # MySQLdb install
-    sudo -- sh -c 'yum install -y python3-mysqlclient'
     # NODEJS 14 install
     sudo -- sh -c 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs'
     # Pip modules install


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add PyMySQL (MIT Licensed) to support MySQL.

## How was this patch tested?
Tested on a Python 3 cluster as well as locally on my machine.

Ignore when the commits were committed. I amended the log and pushed here so it thinks the commits are recent. No changes have been made since Hue was tested.
