### PR TITLE
ODP-2074 : Upgraded pip package "markdown" version to 3.2.2

### DIFF
--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -39,7 +39,7 @@ kerberos==1.3.0
 kubernetes==26.1.0
 lockfile==0.12.2
 Mako==1.2.3
-Markdown==3.1
+Markdown==3.2.2
 openpyxl==3.0.9
 phoenixdb==1.2.1
 prompt-toolkit==3.0.39


### PR DESCRIPTION
## What changes were proposed in this pull request?

ODP-2074 : Upgraded pip package "markdown" version to 3.2.2 to fix the compile / runtime error caused due to deprecated module in setuptools

## How was this patch tested?

Installed and was able to run hue in local environments
