### PR TITLE
ODP-4445 : Add required files for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,8 @@ INSTALL_CORE_FILES = \
 	ext \
 	tools/app_reg \
 	$(INSTALL_DIR) \
+	tools/virtual-bootstrap \
+	tools/relocatable.py \
 	VERS* LICENSE* README*
 
 .PHONY: install


### PR DESCRIPTION
## What changes were proposed in this pull request?

ODP-4445 : Add required files for packaging

## How was this patch tested?

```bash
Wrote: /root/harshith/ODP-4445/final-bigtop/odp-bigtop/build/hue/rpm/RPMS/x86_64/hue_3_3_6_2_1-zookeeper-4.11.0.3.3.6.2-1.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.WbuOOd
+ umask 022
+ cd /root/harshith/ODP-4445/final-bigtop/odp-bigtop/build/hue/rpm//BUILD
+ cd hue-4.11.0.3.3.6.2-1
+ /usr/bin/rm -rf /root/harshith/ODP-4445/final-bigtop/odp-bigtop/build/hue/rpm/BUILDROOT/hue_3_3_6_2_1-4.11.0.3.3.6.2-1.x86_64
+ exit 0
Executing(--clean): /bin/sh -e /var/tmp/rpm-tmp.bCFYhe
+ umask 022
+ cd /root/harshith/ODP-4445/final-bigtop/odp-bigtop/build/hue/rpm//BUILD
+ rm -rf hue-4.11.0.3.3.6.2-1
+ exit 0
[ant:touch] Creating /root/harshith/ODP-4445/final-bigtop/odp-bigtop/build/hue/.rpm
:hue-rpm (Thread[Execution worker for ':',5,main]) completed. Took 8 mins 28.998 secs.

BUILD SUCCESSFUL in 8m 30s
5 actionable tasks: 5 executed
```
