### PR TITLE
ODP-4518 : Fix hue compile issue with pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ virtual-env: $(BLD_DIR_ENV)/bin/python
 $(BLD_DIR_ENV)/bin/python:
 	@echo "--- Creating virtual environment for $(PYTHON_VER) ---"
 	@mkdir -p $(BLD_DIR_ENV)
+	@$(SYS_PYTHON) -m ensurepip --upgrade
 	@$(SYS_PYTHON) -m pip install --upgrade pip==$(PIP_VERSION)
 	@$(SYS_PYTHON) -m pip install virtualenv==$(VIRTUAL_ENV_VERSION) virtualenv-make-relocatable==$(VIRTUAL_ENV_RELOCATABLE_VERSION)
 	@$(SYS_PYTHON) -m virtualenv --copies -p $(PYTHON_VER) $(BLD_DIR_ENV)


### PR DESCRIPTION
## What changes were proposed in this pull request?

ODP-4518 : Fix hue compile issue with pip

## How was this patch tested?

Build success
```bash
Wrote: /root/hue_issue/odp-bigtop/build/hue/rpm/RPMS/x86_64/hue_3_3_6_2_1-rdbms-4.11.0.3.3.6.2-1.x86_64.rpm
Wrote: /root/hue_issue/odp-bigtop/build/hue/rpm/RPMS/x86_64/hue_3_3_6_2_1-security-4.11.0.3.3.6.2-1.x86_64.rpm
Wrote: /root/hue_issue/odp-bigtop/build/hue/rpm/RPMS/x86_64/hue_3_3_6_2_1-useradmin-4.11.0.3.3.6.2-1.x86_64.rpm
Wrote: /root/hue_issue/odp-bigtop/build/hue/rpm/RPMS/x86_64/hue_3_3_6_2_1-spark-4.11.0.3.3.6.2-1.x86_64.rpm
Wrote: /root/hue_issue/odp-bigtop/build/hue/rpm/RPMS/x86_64/hue_3_3_6_2_1-zookeeper-4.11.0.3.3.6.2-1.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.o7BbQZ
+ umask 022
+ cd /root/hue_issue/odp-bigtop/build/hue/rpm//BUILD
+ cd hue-4.11.0.3.3.6.2-1
+ /usr/bin/rm -rf /root/hue_issue/odp-bigtop/build/hue/rpm/BUILDROOT/hue_3_3_6_2_1-4.11.0.3.3.6.2-1.x86_64
+ exit 0
Executing(--clean): /bin/sh -e /var/tmp/rpm-tmp.pdhbJb
+ umask 022
+ cd /root/hue_issue/odp-bigtop/build/hue/rpm//BUILD
+ rm -rf hue-4.11.0.3.3.6.2-1
+ exit 0
[ant:touch] Creating /root/hue_issue/odp-bigtop/build/hue/.rpm
:hue-rpm (Thread[Execution worker for ':',5,main]) completed. Took 14 mins 40.624 secs.

BUILD SUCCESSFUL in 14m 43s
5 actionable tasks: 5 executed
```
