### PR TITLE
ODP-6169: Point to fixed forked cx_Oracle repository

### DIFF
--- a/desktop/core/generate_requirements.py
+++ b/desktop/core/generate_requirements.py
@@ -37,7 +37,7 @@ class RequirementsGenerator:
             "channels==4.0.0",
             "channels-redis==4.0.0",
             "configobj==5.0.9",
-            "cx-Oracle==8.3.0",
+            "git+https://github.com/acceldata-io/python-cx_Oracle",
             "django-auth-ldap==4.3.0",
             "Django==4.1.13",
             "daphne==3.0.2",


### PR DESCRIPTION
This points to a new forked repo that fixes issues in the upstream (abandoned) library, cx_Oracle.

This is the [commit](https://github.com/acceldata-io/python-cx_Oracle/commit/b28ffcb2592dd93a8e80515b03332f8d69e89bbe) that fixes issues in setup.py. 