### PR TITLE
ODP-6660: Make unix usersync work

### DIFF
--- a/apps/useradmin/src/useradmin/management/commands/useradmin_sync_with_unix.py
+++ b/apps/useradmin/src/useradmin/management/commands/useradmin_sync_with_unix.py
@@ -28,10 +28,10 @@ class Command(BaseCommand):
   Handler for syncing the Hue database with Unix users and groups
   """
   def add_arguments(self, parser):
-    parser.add_argument("--min-uid", help=_("Minimum UID to import (Inclusive)."), default=500)
-    parser.add_argument("--max-uid", help=_("Maximum UID to import (Exclusive)."), default=65334)
-    parser.add_argument("--min-gid", help=_("Minimum GID to import (Inclusive)."), default=500)
-    parser.add_argument("--max-gid", help=_("Maximum GID to import (Exclusive)."), default=65334)
+    parser.add_argument("--min-uid", help=_("Minimum UID to import (Inclusive)."), default=500, type=int)
+    parser.add_argument("--max-uid", help=_("Maximum UID to import (Exclusive)."), default=65334, type=int)
+    parser.add_argument("--min-gid", help=_("Minimum GID to import (Inclusive)."), default=500, type=int)
+    parser.add_argument("--max-gid", help=_("Maximum GID to import (Exclusive)."), default=65334, type=int)
     parser.add_argument("--check-shell", help=_("Whether or not to check that the user's shell is not /bin/false."), default=True)
 
   def handle(self, *args, **options):

--- a/apps/useradmin/src/useradmin/views.py
+++ b/apps/useradmin/src/useradmin/views.py
@@ -920,10 +920,10 @@ def sync_unix_users_and_groups(min_uid, max_uid, min_gid, max_gid, check_shell):
     # access the associated list of groups
     hue_user.save()
     if username not in user_groups:
-      hue_user.groups = []
+      hue_user.groups.set([])
     else:
       # Here's where that user to group map we built comes in handy
-      hue_user.groups = user_groups[username]
+      hue_user.groups.set(user_groups[username])
     hue_user.save()
     LOG.info(_("Synced user %s from Unix") % hue_user.username)
 


### PR DESCRIPTION
This fixes unix usersync to actually work. Previously, this functionality was exposed in the Mpack UI but did nothing, and with the latest mpack, enabling it does something. These changes were required to get it to work as expected.

The code in `apps/useradmin/src/useradmin/views.py` hasn't been touched in ~14 years.

Without the changes to `useradmin_sync_with_unix.py`, you get an error like the following:

```                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/odp/3.3.6.3-101/hue/apps/useradmin/src/useradmin/views.py", line 907, in <genexpr>
    if (user.pw_uid >= min_uid and user.pw_uid < max_uid) or user.pw_name in grp.getgrnam('hadoop').gr_mem)
        ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'int' and 'str'
```

Here is an example of the sync function having worked.

<img width="1548" height="1030" alt="image" src="https://github.com/user-attachments/assets/48d492f0-aa5b-434d-9f53-788d537cc12a" />
